### PR TITLE
further debranding

### DIFF
--- a/settings/dev/001_default.yml
+++ b/settings/dev/001_default.yml
@@ -60,7 +60,7 @@ notification:
     smtp_port: 1025
     smtp_user: "test"
     smtp_password: "test"
-    sender: "test@sofort-impfen.de"
+    sender: "kontakt@kiebitz.eu"
     mail_subject: "Neue Impftermine verfügbar!"
     mail_delay: 1
     mail_template: >


### PR DESCRIPTION
we should take out non active things
now only

```
.gitlab-ci.yml
settings\dev\001_default.yml
settings\staging\001_default.yml
```
are to be cleaned but this I would rather leave to @adewes or @bkastl