### PR TITLE
Enables redis sentinel & redis sharding

### DIFF
--- a/databases/databases.go
+++ b/databases/databases.go
@@ -24,13 +24,13 @@ var Databases = services.DatabaseDefinitions{
 	"redis": services.DatabaseDefinition{
 		Name:              "Redis Database",
 		Description:       "For Production Use",
-		Maker:             MakeRedis,
+		Maker:             MakeRedisAsDatabase,
 		SettingsValidator: ValidateRedisSettings,
 	},
 	"redis-shard": services.DatabaseDefinition{
 		Name:              "Redis Sharded Database",
 		Description:       "For Production Use",
-		Maker:             MakeRedisShards,
+		Maker:             MakeRedisShardAsDatabase,
 		SettingsValidator: ValidateRedisShardSettings,
 	},
 	"in-memory": services.DatabaseDefinition{

--- a/databases/databases.go
+++ b/databases/databases.go
@@ -27,6 +27,12 @@ var Databases = services.DatabaseDefinitions{
 		Maker:             MakeRedis,
 		SettingsValidator: ValidateRedisSettings,
 	},
+	"redis-shard": services.DatabaseDefinition{
+		Name:              "Redis Sharded Database",
+		Description:       "For Production Use",
+		Maker:             MakeRedisShards,
+		SettingsValidator: ValidateRedisShardSettings,
+	},
 	"in-memory": services.DatabaseDefinition{
 		Name:              "In-memory Database (no persistence! just use for testing)",
 		Description:       "An in-memory database for testing only",

--- a/databases/redis.go
+++ b/databases/redis.go
@@ -362,7 +362,6 @@ func (d *Redis) getShardForKey(key string) uint32 {
 }
 
 func (d *Redis) Client(key string) redis.UniversalClient {
-	return d.clients[0]
 	return d.clients[d.getShardForKey(key)]
 }
 

--- a/meters/meters.go
+++ b/meters/meters.go
@@ -18,13 +18,20 @@ package meters
 
 import (
 	"github.com/kiebitz-oss/services"
+	"github.com/kiebitz-oss/services/databases"
 )
 
 var Meters = services.MeterDefinitions{
 	"redis": services.MeterDefinition{
-		Name:              "Redis Meter",
+		Name:              "Redis Meter Database",
 		Description:       "For Production Use",
 		Maker:             MakeRedis,
-		SettingsValidator: ValidateRedisSettings,
+		SettingsValidator: databases.ValidateRedisSettings,
+	},
+	"redis-shard": services.MeterDefinition{
+		Name:              "Redis Sharded Meter Database",
+		Description:       "For Production Use",
+		Maker:             MakeRedisShards,
+		SettingsValidator: databases.ValidateRedisShardSettings,
 	},
 }

--- a/settings/dev/001_default.yml
+++ b/settings/dev/001_default.yml
@@ -8,11 +8,19 @@ meter:
     password: ""
 database:
   name: db
-  type: redis
+  type: redis-shard
   settings:
-    addresses: [ "localhost:6379" ]
-    database: 0
-    password: ""
+    shards:
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
+
 metrics:
   bind_address: "localhost:9090"
 storage:

--- a/settings/dev/001_default.yml
+++ b/settings/dev/001_default.yml
@@ -1,11 +1,18 @@
 name: kiebitz
 meter:
   name: meter
-  type: redis
+  type: redis-shard
   settings:
-    addresses: [ "localhost:6379" ]
-    database: 1
-    password: ""
+    shards:
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
+      - addresses: [ "localhost:6379" ]
+        password: ""
+        database: 1
 database:
   name: db
   type: redis-shard

--- a/settings/dev/001_default.yml
+++ b/settings/dev/001_default.yml
@@ -1,33 +1,18 @@
 name: kiebitz
 meter:
   name: meter
-  type: redis-shard
+  type: redis
   settings:
-    shards:
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
+    addresses: [ "localhost:6379" ]
+    database: 1
+    password: ""
 database:
   name: db
-  type: redis-shard
+  type: redis
   settings:
-    shards:
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
-      - addresses: [ "localhost:6379" ]
-        password: ""
-        database: 1
-
+    addresses: [ "localhost:6379" ]
+    database: 0
+    password: ""
 metrics:
   bind_address: "localhost:9090"
 storage:


### PR DESCRIPTION
This introduces two things:

* Multiple configuration options for sentinel support
  * We allow in our configuration objects to use the sentinel functionality of the go-redis application. This is completly optional.
* Application-based sharding
  * We allow to specify the new `redis-shard` configuration option. This allows us to use multiple databases to back the application. We hash the redis key and select the applicable shard for each key. This builds on top of the existing redis implementation and implements a single-node redis as a shard connection with one chart.